### PR TITLE
Test refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,21 +6,21 @@ version = 3
 name = "a1"
 version = "0.1.0"
 dependencies = [
- "assert_cmd",
+ "test_run_bin",
 ]
 
 [[package]]
 name = "a2"
 version = "0.1.0"
 dependencies = [
- "assert_cmd",
+ "test_run_bin",
 ]
 
 [[package]]
 name = "a3"
 version = "0.1.0"
 dependencies = [
- "assert_cmd",
+ "test_run_bin",
  "unicode-segmentation",
 ]
 
@@ -28,27 +28,27 @@ dependencies = [
 name = "a4"
 version = "0.1.0"
 dependencies = [
- "assert_cmd",
+ "test_run_bin",
 ]
 
 [[package]]
 name = "a5"
 version = "0.1.0"
 dependencies = [
- "assert_cmd",
  "predicates",
  "quickcheck",
  "read_u32",
+ "test_run_bin",
 ]
 
 [[package]]
 name = "a6"
 version = "0.1.0"
 dependencies = [
- "assert_cmd",
  "criterion",
  "primal",
  "read_u32",
+ "test_run_bin",
 ]
 
 [[package]]
@@ -765,6 +765,13 @@ name = "termtree"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
+
+[[package]]
+name = "test_run_bin"
+version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+]
 
 [[package]]
 name = "textwrap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,12 @@
 [workspace]
 
-members = ["a1", "a2", "a3", "a4", "a5", "a6", "read_u32"]
+members = [
+    "a1",
+    "a2",
+    "a3",
+    "a4",
+    "a5",
+    "a6",
+    "read_u32",
+    "test_run_bin",
+]

--- a/a1/Cargo.toml
+++ b/a1/Cargo.toml
@@ -11,4 +11,4 @@ description = "Solution for SPCC Kickstart Problem A1"
 [dependencies]
 
 [dev-dependencies]
-assert_cmd = "2.0"
+test_run_bin = { path = "../test_run_bin" }

--- a/a1/tests/basic.rs
+++ b/a1/tests/basic.rs
@@ -1,15 +1,6 @@
-#![cfg(not(miri))] // miri can't run other executables
+#![cfg(not(miri))]
 
-/// Runs the main executable and writes `input` to stdin,
-/// then ensures that it produces `output` in stdout.
-fn run(input: &str, output: &'static str) {
-    assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME"))
-        .unwrap()
-        .write_stdin(input)
-        .assert()
-        .success()
-        .stdout(output);
-}
+test_run_bin::initialize!();
 
 #[test]
 fn samples() {

--- a/a2/Cargo.toml
+++ b/a2/Cargo.toml
@@ -11,4 +11,4 @@ description = "Solution for SPCC Kickstart Problem A2"
 [dependencies]
 
 [dev-dependencies]
-assert_cmd = "2.0"
+test_run_bin = { path = "../test_run_bin" }

--- a/a2/tests/basic.rs
+++ b/a2/tests/basic.rs
@@ -1,15 +1,6 @@
 #![cfg(not(miri))] // miri can't run other executables
 
-/// Runs the main executable and writes `input` to stdin,
-/// then ensures that it produces `output` in stdout.
-fn run(input: &str, output: &'static str) {
-    assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME"))
-        .unwrap()
-        .write_stdin(input)
-        .assert()
-        .success()
-        .stdout(output);
-}
+test_run_bin::initialize!();
 
 const YES: &str = "YES\n";
 const NO: &str = "NO\n";

--- a/a3/Cargo.toml
+++ b/a3/Cargo.toml
@@ -12,4 +12,4 @@ description = "Solution for SPCC Kickstart Problem A3"
 unicode-segmentation = "1.9"
 
 [dev-dependencies]
-assert_cmd = "2.0"
+test_run_bin = { path = "../test_run_bin" }

--- a/a3/tests/basic.rs
+++ b/a3/tests/basic.rs
@@ -5,37 +5,28 @@
 // it complains if we put this directly above `fn unicode()`.
 #![allow(clippy::unicode_not_nfc)]
 
-/// Runs the main executable and writes `input` to stdin,
-/// then ensures that it produces `output` in stdout (as a string).
-fn run(input: &str, output: u32) {
-    assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME"))
-        .unwrap()
-        .write_stdin(input)
-        .assert()
-        .success()
-        .stdout(format!("{output}\n"));
-}
+test_run_bin::initialize!();
 
 #[test]
 fn samples() {
-    run("SPCC", 0);
-    run("Computer Club", 4);
+    run("SPCC", "0\n");
+    run("Computer Club", "4\n");
 }
 
 #[test]
 fn vowels_and_consonants() {
-    run("aeiouAEIOU", 10);
-    run("bcdfghjklmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ", 0);
+    run("aeiouAEIOU", "10\n");
+    run("bcdfghjklmnpqrstvwxyzBCDFGHJKLMNPQRSTVWXYZ", "0\n");
 }
 
 #[test]
 fn short_and_long() {
     // `len(s)` = 1
-    run("a", 1);
-    run("b", 0);
+    run("a", "1\n");
+    run("b", "0\n");
 
-    run(&"a".repeat(100), 100);
-    run(&"b".repeat(100), 0);
+    run(&"a".repeat(100), "100\n");
+    run(&"b".repeat(100), "0\n");
 }
 
 #[test]
@@ -43,14 +34,14 @@ fn short_and_long() {
 fn Chinese() {
     // This is equivalent to "\u{5141}".
     // Its second byte is exactly the ASCII character 'A'.
-    run("允", 0);
+    run("允", "0\n");
 
     // these strings have more than 100 bytes,
     // but `len(s)` in Python would still return 100.
-    run(&"測試".repeat(50), 0);
+    run(&"測試".repeat(50), "0\n");
     // make sure we don't ignore the first or last characters
-    run(&"A測試B".repeat(25), 25);
-    run(&"B測試A".repeat(25), 25);
+    run(&"A測試B".repeat(25), "25\n");
+    run(&"B測試A".repeat(25), "25\n");
 }
 
 #[test]
@@ -58,9 +49,9 @@ fn unicode() {
     // This is equivalent to "\u{0065}\u{0301}".
     // U+0065: 'latin small letter e'
     // U+0301: 'combining acute accent'
-    run("é", 0);
+    run("é", "0\n");
 
     // This is equilvalent to "\u{00e9}".
     // U+00e9: 'latin small letter e with acute'
-    run("é", 0);
+    run("é", "0\n");
 }

--- a/a4/Cargo.toml
+++ b/a4/Cargo.toml
@@ -11,4 +11,4 @@ description = "Solution for SPCC Kickstart Problem A4"
 [dependencies]
 
 [dev-dependencies]
-assert_cmd = "2.0"
+test_run_bin = { path = "../test_run_bin" }

--- a/a4/tests/basic.rs
+++ b/a4/tests/basic.rs
@@ -1,33 +1,24 @@
 #![cfg(not(miri))] // miri can't run other executables
 
-/// Runs the main executable and writes `input` to stdin (as a string),
-/// then ensures that it produces `output` in stdout (as a string).
-fn run(input: u32, output: u32) {
-    assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME"))
-        .unwrap()
-        .write_stdin(format!("{input}"))
-        .assert()
-        .success()
-        .stdout(format!("{output}\n"));
-}
+test_run_bin::initialize!();
 
 #[test]
 fn samples() {
-    run(15, 5);
-    run(100, 34);
+    run("15", "5\n");
+    run("100", "34\n");
 }
 
 // Unfortunately, our tests have to assume that our way of
 // climbing stairs is correct.
 #[test]
 fn edge_cases() {
-    run(1, 1);
-    run(2, 1);
-    run(3, 1);
-    run(4, 2);
+    run("1", "1\n");
+    run("2", "1\n");
+    run("3", "1\n");
+    run("4", "2\n");
 
-    run(999_997, 333_333);
-    run(999_998, 333_333);
-    run(999_999, 333_333);
-    run(1_000_000, 333_334);
+    run("999997", "333333\n");
+    run("999998", "333333\n");
+    run("999999", "333333\n");
+    run("1000000", "333334\n");
 }

--- a/a5/Cargo.toml
+++ b/a5/Cargo.toml
@@ -12,6 +12,6 @@ description = "Solution for SPCC Kickstart Problem A5"
 read_u32 = { path = "../read_u32" }
 
 [dev-dependencies]
-assert_cmd = "2.0"
+test_run_bin = { path = "../test_run_bin" }
 predicates = "2.1"
 quickcheck = "1"

--- a/a5/tests/basic.rs
+++ b/a5/tests/basic.rs
@@ -1,15 +1,6 @@
 #![cfg(not(miri))] // miri can't run other executables
 
-/// Runs the main executable and writes `input` to stdin,
-/// then ensures that it produces `output` in stdout.
-fn run(input: &str, output: &'static str) {
-    assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME"))
-        .unwrap()
-        .write_stdin(input)
-        .assert()
-        .success()
-        .stdout(output);
-}
+test_run_bin::initialize!();
 
 #[test]
 fn sample() {

--- a/a6/Cargo.toml
+++ b/a6/Cargo.toml
@@ -12,7 +12,7 @@ description = "Solution for SPCC Kickstart Problem A6"
 read_u32 = { path = "../read_u32" }
 
 [dev-dependencies]
-assert_cmd = "2.0"
+test_run_bin = { path = "../test_run_bin" }
 criterion = "0.3"
 primal = "0.3"
 

--- a/a6/tests/basic.rs
+++ b/a6/tests/basic.rs
@@ -1,15 +1,6 @@
 #![cfg(not(miri))] // miri can't run other executables
 
-/// Runs the main executable and writes `input` to stdin,
-/// then ensures that it produces `output` in stdout.
-fn run(input: &str, output: &'static str) {
-    assert_cmd::Command::cargo_bin(env!("CARGO_PKG_NAME"))
-        .unwrap()
-        .write_stdin(input)
-        .assert()
-        .success()
-        .stdout(output);
-}
+test_run_bin::initialize!();
 
 #[test]
 fn sample() {

--- a/test_run_bin/Cargo.toml
+++ b/test_run_bin/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "test_run_bin"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+assert_cmd = "2.0"

--- a/test_run_bin/src/lib.rs
+++ b/test_run_bin/src/lib.rs
@@ -1,0 +1,29 @@
+#[doc(hidden)]
+pub fn run(package_name: &str, input: &str, output: &'static str) {
+    assert_cmd::Command::cargo_bin(package_name)
+        .unwrap()
+        .write_stdin(input)
+        .assert()
+        .success()
+        .stdout(output);
+}
+
+/// Creates a `run` function that ensures that the program produces `output` when given `input`.
+/// This is a macro to make sure that the `env` macro expands within the test.
+///
+/// Note that this function cannot be used with `miri`.
+/// Declare `#![cfg(not(miri))]` at the top of the test file.
+#[macro_export]
+macro_rules! initialize {
+    () => {
+        /// Runs the main executable and writes `input` to stdin,
+        /// then ensures that it produces `output` in stdout.
+        ///
+        /// # Panics
+        ///
+        /// Panics when the program does not produce `output`.
+        fn run(input: &str, output: &'static str) {
+            $crate::run(env!("CARGO_PKG_NAME"), input, output);
+        }
+    };
+}


### PR DESCRIPTION
Instead of copying similar `run` functions to every test to run the corresponding binary, centralize to one crate `test_run_bin` and allow all other crates to depend on `test_run_bin`.